### PR TITLE
Make MMMAutoLayoutScrollView compatible with iOS 26

### DIFF
--- a/MMMCommonUI.podspec
+++ b/MMMCommonUI.podspec
@@ -6,7 +6,7 @@
 Pod::Spec.new do |s|
 
 	s.name = "MMMCommonUI"
-	s.version = "3.14.1"
+	s.version = "3.14.2"
 	s.summary = "Small UI-related pieces reused in many components from MMMTemple"
 	s.description =	"#{s.summary}."
 	s.homepage = "https://github.com/mediamonks/#{s.name}"

--- a/Sources/MMMCommonUIObjC/MMMAutoLayoutScrollView.m
+++ b/Sources/MMMCommonUIObjC/MMMAutoLayoutScrollView.m
@@ -176,7 +176,7 @@
 
 - (void)addSubview:(UIView *)view {
 	NSAssert(
-		!_hierarchyLocked || [NSStringFromClass([view class]) hasPrefix:@"UI"],
+		!_hierarchyLocked || ([NSStringFromClass([view class]) hasPrefix:@"UI"] || [NSStringFromClass([view class]) hasPrefix:@"_UI"]),
 		@"Add your subviews into `contentView` and not into %@ directly", self.class
 	);
 	[super addSubview:view];


### PR DESCRIPTION
New iOS 26 adds extra subviews prefixed with "_UI".